### PR TITLE
Remember configuration across reboots

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,4 +1,5 @@
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 import { SecondMonitorIndicator } from './lib/indicator.js';
 
 // All other classes, constants, and most imports have been moved to their respective files:
@@ -9,9 +10,10 @@ import { SecondMonitorIndicator } from './lib/indicator.js';
 // - indicator.js: The SecondMonitorIndicator class (imported above).
 
 // Main extension class
-export default class DualMonitorExtension {
+export default class DualMonitorExtension extends Extension {
     enable() {
-        this._indicator = new SecondMonitorIndicator();
+        this._settings = this.getSettings();
+        this._indicator = new SecondMonitorIndicator(this._settings);
         Main.panel.statusArea.quickSettings.addExternalIndicator(this._indicator);
         console.log("Dual Monitor Toggle Enabled");
     }

--- a/lib/indicator.js
+++ b/lib/indicator.js
@@ -4,13 +4,14 @@ import { SecondMonitorToggle } from './toggle.js';
 
 export const SecondMonitorIndicator = GObject.registerClass(
     class SecondMonitorIndicator extends SystemIndicator {
-        _init() {
+        _init(settings) {
             super._init();
-    
+            
+            this._settings = settings;
             this._indicator = this._addIndicator();
             this._indicator.icon_name = 'video-display-symbolic';
     
-            this._secondMonitorToggle = new SecondMonitorToggle(this._indicator);
+            this._secondMonitorToggle = new SecondMonitorToggle(this._indicator, this._settings);
             this.quickSettingsItems.push(this._secondMonitorToggle);
         }
     

--- a/lib/menu.js
+++ b/lib/menu.js
@@ -102,6 +102,7 @@ export function buildMonitorMenu(toggle) {
 
         item.connect('activate', async () => {
             toggle._monitor = connector;
+            toggle._settings.set_string('monitor-setting', toggle._monitor);
             await toggle._getMonitorConfig();
         });
         toggle.menu.addMenuItem(item);
@@ -129,6 +130,7 @@ export function buildMonitorMenu(toggle) {
     toggle._tempModeMenuItem.connect('activate', () => {
         if (toggle._persistenceMode !== 1) {
             toggle._persistenceMode = 1;
+            toggle._settings.set_int('mode-setting', 1);
             updatePersistenceModeSelectionInMenu(toggle);
         }
     });
@@ -151,6 +153,7 @@ export function buildMonitorMenu(toggle) {
     toggle._persistentModeMenuItem.connect('activate', () => {
         if (toggle._persistenceMode !== 2) {
             toggle._persistenceMode = 2;
+            toggle._settings.set_int('mode-setting', 2);
             updatePersistenceModeSelectionInMenu(toggle);
         }
     });

--- a/lib/toggle.js
+++ b/lib/toggle.js
@@ -10,7 +10,7 @@ import { buildMonitorMenu, updateSelectedMonitorInMenu, updatePersistenceModeSel
 
 export const SecondMonitorToggle = GObject.registerClass(
     class SecondMonitorToggle extends QuickMenuToggle {
-        _init(indicator) {
+        _init(indicator, settings) {
             super._init({
                 title: _('Monitors'),
                 subtitle: '',
@@ -18,6 +18,9 @@ export const SecondMonitorToggle = GObject.registerClass(
                 toggleMode: true,
             });
 
+            this._settings = settings;
+            const modeSetting = this._settings.get_int('mode-setting');            
+            
             this._indicator = indicator;
             this._proxy = null;
             this._monitors = [];
@@ -28,7 +31,7 @@ export const SecondMonitorToggle = GObject.registerClass(
             this._layoutMode = 1;
             this._supportsChangingLayoutMode = false;
             this._monitor = null;
-            this._persistenceMode = PERSISTENT_MODE;
+            this._persistenceMode = (modeSetting === 1 || modeSetting === 2) ? modeSetting : PERSISTENT_MODE;
             this._menuInitiallyBuilt = false;
             this._cachedMonitorsForBuild = '[]';
             this._timeoutId = null;
@@ -109,7 +112,13 @@ export const SecondMonitorToggle = GObject.registerClass(
                 this._supportsChangingLayoutMode = newProperties['supports-changing-layout-mode']?.deepUnpack() ?? false;
 
                 if (!this._monitor && this._monitors.length > 0) {
-                    if (this._monitors.length === 1) {
+
+                    const savedConnector = this._settings.get_string('monitor-setting');
+                    const monitorExists = this._monitors.some(m => m[0][0] === savedConnector);
+    
+                    if (savedConnector && monitorExists) {
+                        this._monitor = savedConnector; // Default to monitor saved in settings if available
+                    } else if (this._monitors.length === 1) {
                         this._monitor = this._monitors[0][0][0];
                     } else {
                         this._monitor = this._monitors[1][0][0]; // Default to second if multiple

--- a/lib/toggle.js
+++ b/lib/toggle.js
@@ -117,7 +117,7 @@ export const SecondMonitorToggle = GObject.registerClass(
                     const monitorExists = this._monitors.some(m => m[0][0] === savedConnector);
     
                     if (savedConnector && monitorExists) {
-                        this._monitor = savedConnector; // Default to monitor saved in settings if available
+                        this._monitor = savedConnector;
                     } else if (this._monitors.length === 1) {
                         this._monitor = this._monitors[0][0][0];
                     } else {

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,7 @@
     "47",
     "48"
   ],
+  "settings-schema": "org.gnome.shell.extensions.dual-monitor-toggle",
   "url": "https://github.com/poka-IT/gnome-dual-monitor-toggle",
   "uuid": "dual-monitor-toggle@poka",
   "version": 8

--- a/schemas/org.gnome.shell.extensions.dual-monitor-toggle.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dual-monitor-toggle.gschema.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.dual-monitor-toggle" path="/org/gnome/shell/extensions/dual-monitor-toggle/">
+    <key name="mode-setting" type="i">
+      <default>2</default>
+      <summary>Configuration mode setting</summary>
+      <description>1 for Temporary Mode, 2 for Persistent Mode.</description>
+    </key>
+    <key name="monitor-setting" type="s">
+      <default>""</default>
+      <summary>Selected monitor setting</summary>
+      <description>Stores the connector name of the monitor chosen in the quick toggle (e.g. HDMI-1, DP-2).</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
### Summary 
This addresses the [issue](https://github.com/poka-IT/gnome-dual-monitor-toggle/issues/5) where the configuration is reset to defaults after reboot.  


### Description

This update ensures that the extension now saves and restores the selected monitor and configuration mode across reboots. If the saved settings are invalid (e.g., the saved monitor no longer exists), the extension will revert to the default behavior.


### Changes Introduced 

#### gschema.xml 

- Adds the GSettings key `monitor-setting` (string) to save the selected monitor connector (DVI-D-0 or HDMI-A-0 in my case).
- Adds the GSettings key `mode-setting` (int) to save persistence mode (1 = Temporary, 2 = Persistent).

#### metadata.json

- Adds a "settings-schema" entry to to declare the schema for GSettings.

#### extension.js

- Initializes settings and passes them to indicator.js.

#### indicator.js

- Receives settings and passes them to toggle.js.

#### toggle.js

- Defines `this._persistenceMode` to be the value saved in `mode-setting` if valid (either 1 for temporary or 2 for Persistent), otherwise uses the default value `PERSISTENT_MODE` as previously defined.
- Defines `this._monitor` to be the value saved in `monitor-setting` if valid (if it currently exists in the list of monitors found), otherwise uses the default value previously defined by the extension (second monitor if multiple displays are found )

#### menu.js

- Saves the settings when a monitor or mode configuration is selected.


### Installation

If manually installing, it is required to compile the schemas followed by a reboot or logout/login (this is handled automatically when installing from the GNOME Extensions app or when using `gnome-extensions install`)

To compile schemas:
`cd ~/.local/share/gnome-shell/extensions/dual-monitor-toggle@poka/ && glib-compile-schemas schemas/`